### PR TITLE
Expand running_in_container? check to handle Kubernetes, probably

### DIFF
--- a/lib/berkeley_library/docker.rb
+++ b/lib/berkeley_library/docker.rb
@@ -7,17 +7,21 @@ module BerkeleyLibrary
   module Docker
     class << self
       def running_in_container?
-        File.exist?('/.dockerenv') || init_cgroup_is_dockerish?
+        File.exist?('/.dockerenv') || init_cgroup_is_dockerish? || env_is_k8sish?
       end
 
       private
 
       def init_cgroup_is_dockerish?
         begin
-          File.open('/proc/1/cgroup').read.match?(%r{(/docker|/lxc|/kubepods)})
+          File.open('/proc/1/cgroup').read.match?(%r{(/docker|/lxc)})
         rescue
           false
         end
+      end
+
+      def env_is_k8sish?
+        ENV.key?('KUBERNETES_SERVICE_HOST')
       end
     end
   end

--- a/lib/berkeley_library/docker.rb
+++ b/lib/berkeley_library/docker.rb
@@ -14,7 +14,7 @@ module BerkeleyLibrary
 
       def init_cgroup_is_dockerish?
         begin
-          File.open('/proc/1/cgroup').read.match?(%r{(/docker|/lxc)})
+          File.open('/proc/1/cgroup').read.match?(%r{(/docker|/lxc|/kubepods)})
         rescue
           false
         end

--- a/spec/berkeley_library/docker_spec.rb
+++ b/spec/berkeley_library/docker_spec.rb
@@ -19,6 +19,20 @@ module BerkeleyLibrary
         1:name=systemd:/docker/12345
       EOL
 
+      KUBEISH_CGROUP = <<~EOL
+        11:perf_event:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        10:hugetlb:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        9:devices:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        8:net_cls,net_prio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        7:blkio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        6:cpu,cpuacct:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        5:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        4:cpuset:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        3:freezer:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        2:memory:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+        1:name=systemd:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
+      EOL
+
       TRADITIONAL_CGROUP = <<~EOL
         11:cpuacct,cpu:/
         10:devices:/
@@ -33,6 +47,12 @@ module BerkeleyLibrary
         1:name=systemd:/
       EOL
 
+      CGROUPS = {
+        trad: TRADITIONAL_CGROUP,
+        kube: KUBEISH_CGROUP,
+        docker: DOCKERISH_CGROUP
+      }
+
       it 'is true when /.dockerenv exists' do
         mock_dockerenv
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
@@ -40,13 +60,19 @@ module BerkeleyLibrary
 
       it 'is true when /proc/1/cgroup is docker-like' do
         mock_dockerenv(false)
-        mock_init_cgroup
+        mock_init_cgroup(:docker)
+        expect(BerkeleyLibrary::Docker.running_in_container?).to be true
+      end
+
+      it 'is true when /proc/1/cgroup is kube-like' do
+        mock_dockerenv(false)
+        mock_init_cgroup(:kube)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
       it 'is false when /proc/1/cgroup is traditional' do
         mock_dockerenv(false)
-        mock_init_cgroup(false)
+        mock_init_cgroup(:trad)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be false
       end
 
@@ -66,11 +92,11 @@ module BerkeleyLibrary
           .and_return(exists)
       end
 
-      def mock_init_cgroup(dockerish = true)
+      def mock_init_cgroup(type)
+        cgroup_data = CGROUPS.fetch(type)
         expect(File)
           .to receive(:open).with('/proc/1/cgroup')
-          .and_return(
-            StringIO.new(dockerish ? DOCKERISH_CGROUP : TRADITIONAL_CGROUP))
+          .and_return(StringIO.new(cgroup_data))
       end
     end
   end

--- a/spec/berkeley_library/docker_spec.rb
+++ b/spec/berkeley_library/docker_spec.rb
@@ -19,20 +19,6 @@ module BerkeleyLibrary
         1:name=systemd:/docker/12345
       EOL
 
-      KUBEISH_CGROUP = <<~EOL
-        11:perf_event:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        10:hugetlb:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        9:devices:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        8:net_cls,net_prio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        7:blkio:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        6:cpu,cpuacct:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        5:pids:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        4:cpuset:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        3:freezer:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        2:memory:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-        1:name=systemd:/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod9a_bc_de_f0_12.slice/cri-containerd-12345.scope
-      EOL
-
       TRADITIONAL_CGROUP = <<~EOL
         11:cpuacct,cpu:/
         10:devices:/
@@ -49,7 +35,6 @@ module BerkeleyLibrary
 
       CGROUPS = {
         trad: TRADITIONAL_CGROUP,
-        kube: KUBEISH_CGROUP,
         docker: DOCKERISH_CGROUP
       }
 
@@ -58,15 +43,14 @@ module BerkeleyLibrary
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
-      it 'is true when /proc/1/cgroup is docker-like' do
-        mock_dockerenv(false)
-        mock_init_cgroup(:docker)
+      it 'is true when KUBERNETES_SERVICE_HOST is set' do
+        mock_k8s_svc_host
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
-      it 'is true when /proc/1/cgroup is kube-like' do
+      it 'is true when /proc/1/cgroup is docker-like' do
         mock_dockerenv(false)
-        mock_init_cgroup(:kube)
+        mock_init_cgroup(:docker)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
@@ -85,6 +69,10 @@ module BerkeleyLibrary
       end
 
       private
+
+      def mock_k8s_svc_host(set = true)
+        expect(ENV).to receive(:key?).with('KUBERNETES_SERVICE_HOST').and_return(set)
+      end
 
       def mock_dockerenv(exists = true)
         expect(File)


### PR DESCRIPTION
Adds a check for `$KUBERNETES_SERVICE_HOST` to detect Kubernetes containers as well as Docker and LXC.