### PR TITLE
Some fixes for Docker library

### DIFF
--- a/lib/berkeley_library/docker.rb
+++ b/lib/berkeley_library/docker.rb
@@ -7,7 +7,7 @@ module BerkeleyLibrary
   module Docker
     class << self
       def running_in_container?
-        File.exist?('/.dockerenv') || init_cgroup_is_dockerish?
+        File.exist?('/.dockerenv') || init_cgroup_is_dockerish? || env_is_podmanish?
       end
 
       private
@@ -18,6 +18,10 @@ module BerkeleyLibrary
         rescue
           false
         end
+      end
+
+      def env_is_podmanish?
+        ENV.fetch('container', '') == 'podman'
       end
     end
   end

--- a/lib/berkeley_library/docker/module_info.rb
+++ b/lib/berkeley_library/docker/module_info.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 module BerkeleyLibrary
   module Docker
     class ModuleInfo
-      NAME = 'berkeley_library-docker'.freeze
-      AUTHOR = 'Dan Schmidt'.freeze
-      AUTHOR_EMAIL = 'danschmidt5189@berkeley.edu'.freeze
-      SUMMARY = 'Utility functions for Dockerizing Ruby apps'.freeze
-      DESCRIPTION = 'Utility functions for making Ruby apps "just work" in Docker containers.'.freeze
-      LICENSE = 'MIT'.freeze
-      VERSION = '0.2.0'.freeze
-      HOMEPAGE = 'https://github.com/BerkeleyLibrary/docker'.freeze
+      NAME = 'berkeley_library-docker'
+      AUTHOR = 'Dan Schmidt'
+      AUTHOR_EMAIL = 'danschmidt5189@berkeley.edu'
+      SUMMARY = 'Utility functions for Dockerizing Ruby apps'
+      DESCRIPTION = 'Utility functions for making Ruby apps "just work" in Docker containers.'
+      LICENSE = 'MIT'
+      VERSION = '0.3.0.a1'
+      HOMEPAGE = 'https://github.com/BerkeleyLibrary/ruby-docker'
 
       private_class_method :new
     end

--- a/spec/berkeley_library/docker_spec.rb
+++ b/spec/berkeley_library/docker_spec.rb
@@ -35,18 +35,21 @@ module BerkeleyLibrary
 
       it 'is true when /.dockerenv exists' do
         mock_dockerenv
+        mock_podman_env(false)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
       it 'is true when /proc/1/cgroup is docker-like' do
         mock_dockerenv(false)
         mock_init_cgroup
+        mock_podman_env(false)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be true
       end
 
       it 'is false when /proc/1/cgroup is traditional' do
         mock_dockerenv(false)
         mock_init_cgroup(false)
+        mock_podman_env(false)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be false
       end
 
@@ -55,6 +58,21 @@ module BerkeleyLibrary
         expect(File)
           .to receive(:open).with('/proc/1/cgroup')
           .and_raise(Errno::ENOENT)
+        mock_podman_env(false)
+        expect(BerkeleyLibrary::Docker.running_in_container?).to be false
+      end
+
+      it 'is true when container=podman is present in environment' do
+        mock_dockerenv(false)
+        mock_init_cgroup(false)
+        mock_podman_env(true)
+        expect(BerkeleyLibrary::Docker.running_in_container?).to be true
+      end
+
+      it 'is false when container=podman is not present in environment' do
+        mock_dockerenv(false)
+        mock_init_cgroup(false)
+        mock_podman_env(false)
         expect(BerkeleyLibrary::Docker.running_in_container?).to be false
       end
 
@@ -71,6 +89,12 @@ module BerkeleyLibrary
           .to receive(:open).with('/proc/1/cgroup')
           .and_return(
             StringIO.new(dockerish ? DOCKERISH_CGROUP : TRADITIONAL_CGROUP))
+      end
+
+      def mock_podman_env(exists = true)
+        allow(ENV)
+          .to receive(:fetch).with('container', '')
+          .and_return(exists ? 'podman' : '')
       end
     end
   end


### PR DESCRIPTION
* Replace all the .freeze calls with a single `frozen_string_literal` declaration at the top of ModuleInfo.
* Update the version to 0.3.0a1 since we are post-0.2.0 now.
* Add a Podman check to `#running_in_container?`.

The Podman check allows Selenium tests to run and pass from within Podman Desktop on my Arm Mac, and should also work for Linux systems using Podman Desktop.  This also future-proofs us in case we decide to migrate from Docker to Podman at a later date.